### PR TITLE
Added platform detection for AppData config directory

### DIFF
--- a/redliner/common/persistent_dict.py
+++ b/redliner/common/persistent_dict.py
@@ -12,7 +12,7 @@ class PersistentDict(dict):
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self, path: str = ""):
+    def __init__(self, path: os.PathLike | str = ""):
         if not hasattr(self, '_initialized'):  # Prevent re-initialization
             self.defaults = {}
             self.path = path

--- a/redliner/main.py
+++ b/redliner/main.py
@@ -4,6 +4,8 @@ from PyQt6 import QtWidgets as qtw, QtGui as qtg, QtCore as qtc
 
 import threading
 import logging
+from pathlib import Path
+import platform
 
 from redliner.common.constants import VERSION_PATTERN
 from redliner.core.doc_man import DocMan
@@ -52,7 +54,13 @@ if __name__ == "__main__":
     logging.info("Start")
     with TemporaryFileManager() as tfm:
         app = qtw.QApplication(sys.argv)
-        pd = PersistentDict(os.path.join(os.getenv('APPDATA'),"redliner","redliner.json"))
+        if platform.system() == 'Windows':
+            app_data_dir = Path.home() / "AppData" / "Roaming" / "redliner"
+        elif platform.system() == 'Darwin':  # macOS
+            app_data_dir = Path.home() / "Library" / "Application Support" / "redliner"
+        else:  # Linux and other Unix-like systems
+            app_data_dir = Path.home() / ".local" / "share" / "redliner"
+        pd = PersistentDict(app_data_dir / "redliner.json")
         _redliner = Redliner()
         file_check_thread =threading.Thread(target=lambda:fetch_remote_version(_redliner.signalParseUpdates.emit))
         qtc.QTimer.singleShot(1, file_check_thread.start)


### PR DESCRIPTION
Updated the persistent dictionary .json file so that it works on macOS. Not actually tested on Windows yet.

I also used pathlib's Path because it's a builtin module and I think it's better than os.path, but I can adapt it to os.path if you don't want to use pathlib. 

It may also make more sense to wrap the path logic into a getting function? Just throwing this up here since I adapted it but can optimize it depending on how you see the path being used. 