### PR TITLE
Added drag/drop to new/old DocPreview widgets

### DIFF
--- a/redliner/core/doc_man.py
+++ b/redliner/core/doc_man.py
@@ -75,6 +75,12 @@ class DocMan(qtw.QWidget):
         _l.addWidget(self.preview)
         self.fetchers = {f.desc: f for f in [F() for F in FETCHER_TYPES]}
 
+        # Bind the Local Fetcher's fetch to the drag and drop events of the DocPreview
+        self.lhp.signalFileDropRequest.connect(lambda: self.__setattr__("click_side", "L"))
+        self.lhp.signalFileDropRequest.connect(self.fetchers["Local File"].fetch)
+        self.rhp.signalFileDropRequest.connect(lambda: self.__setattr__("click_side", "R"))
+        self.rhp.signalFileDropRequest.connect(self.fetchers["Local File"].fetch)
+
         for k, v in self.fetchers.items():
             v.signalDocReady.connect(self.doc_ready)
             gb = qtw.QGroupBox(k)

--- a/redliner/core/ui.py
+++ b/redliner/core/ui.py
@@ -1,15 +1,24 @@
+import logging
 from PyQt6 import QtWidgets as qtw, QtCore as qtc
+from PyQt6.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent
 from redliner.common.constants import PREVIEW_SIZE
 from redliner.extensions.source_doc import SrcDoc
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
 
 class DocPreview(qtw.QListWidget):
     signalSelectionChanged = qtc.pyqtSignal()
+    signalFileDropRequest = qtc.pyqtSignal(Path)
 
     def __init__(self, parent):
         self.parent = parent
         super().__init__()
         self.setUniformItemSizes(True)
         self.setIconSize(PREVIEW_SIZE)
+
+        # Enable drag and drop so we can parse new files that have been dropped onto the DocPreview
+        self.setAcceptDrops(True)
 
     def set_doc(self, doc: SrcDoc):
         self.clear()
@@ -28,3 +37,40 @@ class DocPreview(qtw.QListWidget):
             self.parent.keyPressEvent(e)
         else:
             super().keyPressEvent(e)
+
+    @staticmethod
+    def _urlFromEvent(event: QDragEnterEvent | QDropEvent) -> Path | None:
+        if event.mimeData().hasUrls(): # type: ignore[union-attr]
+            urls = event.mimeData().urls() # type: ignore[union-attr]
+            if len(urls) == 1:
+                return urls[0].toLocalFile() # type: ignore[union-attr]
+        return None
+
+    def dragEnterEvent(self, event: QDragEnterEvent) -> None:
+        # NOTE: Enter event must be accepted before dragEvent is triggered!
+        url = self._urlFromEvent(event)
+        _logger.debug(f"Dragged file entered: {url}")
+        # Check if the URL is a file path
+        if url and Path(url).is_file():
+            # TODO: Handle file type-checking to indicate to the user certain files can't be diffed. I think this
+            # requires a bit of a rethink for how valid files are deteced in Fetcher, so keep it simple for now
+            _logger.debug(f"File allowed: {url}")
+            event.acceptProposedAction() # type: ignore[union-attr]
+        else:
+            _logger.debug(f"File rejected: {url}")
+            event.ignore() # type: ignore[union-attr]
+
+    def dragMoveEvent(self, event: QDragMoveEvent) -> None:
+        # NOTE: Drag event must be accepted before dropEvent is triggered! It should already be verified so we can just
+        # accept.
+        event.acceptProposedAction() 
+
+
+    def dropEvent(self, event: QDropEvent) -> None:
+        url = self._urlFromEvent(event)
+        if url and Path(url).is_file():
+            _logger.info(f"Dragged file dropped: {url}")
+            self.signalFileDropRequest.emit(Path(url))
+            event.acceptProposedAction() # type: ignore[union-attr]
+        else:   
+            event.ignore() # type: ignore[union-attr]

--- a/redliner/core/ui.py
+++ b/redliner/core/ui.py
@@ -39,7 +39,7 @@ class DocPreview(qtw.QListWidget):
             super().keyPressEvent(e)
 
     @staticmethod
-    def _urlFromEvent(event: QDragEnterEvent | QDropEvent) -> Path | None:
+    def _urlFromEvent(event: QDragEnterEvent | QDropEvent) -> qtc.QUrl | None:
         if event.mimeData().hasUrls(): # type: ignore[union-attr]
             urls = event.mimeData().urls() # type: ignore[union-attr]
             if len(urls) == 1:

--- a/redliner/core/ui.py
+++ b/redliner/core/ui.py
@@ -72,5 +72,5 @@ class DocPreview(qtw.QListWidget):
             _logger.info(f"Dragged file dropped: {url}")
             self.signalFileDropRequest.emit(Path(url))
             event.acceptProposedAction() # type: ignore[union-attr]
-        else:   
+        else:
             event.ignore() # type: ignore[union-attr]


### PR DESCRIPTION
Added the ability to drag and drop files onto the DocPreview. 

I don't know if you had some specific architecture you wanted to build for this feature, so I won't be upset if you want to rethink it. 

Basically I:
- Added a new `signalFileDropRequest` to the DocPreview class 
  - Once a file drops, this signal emits a Path object pointing to the dropped file
  - Currently, no compatibility checking is done. It is done later by the Fetcher, we just don't currently indicate to the user the drop will be invalid _before_ the drop occurs
- Updated doc\_man \_\_init\_\_ to connect the signalFileDropRequest to the Local File Fetcher's Fetch method

I'm not sure if this is how the Local File fetcher is intended to be used, but tying into a Fetcher seems to be the correct way to parse a file from a path, and it seemed redundant to use another Fetcher, especially one that doesn't get a button. We could discuss other architectures for this if you don't like it though. 